### PR TITLE
Explicitly set a result format when hitting the job result API

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -157,7 +157,7 @@ TDClient.prototype = {
     jobResult: function(job_id, callback) {
         this._request("/v3/job/result/" + qs.escape(job_id), {
             method: 'GET',
-            qs: { format: 'msgpack' }
+            qs: { format: 'tsv' }
         }, callback);
     },
 


### PR DESCRIPTION
I'm getting a 500 error when calling 'jobResult' function since few days ago, it seems '/v3/job/result/' endpoint does not work properly without explicitly specifying 'format' parameter.
