### PR TITLE
Fix wrong HTTP method in runScheule

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -389,7 +389,7 @@ TDClient.prototype = {
         }
 
         this._request("/v3/schedule/run/" + qs.escape(name) + "/" + qs.escape(time), {
-            method: 'GET',
+            method: 'POST',
             qs: params,
             json: true
         }, callback);

--- a/test/TDMockApi.js
+++ b/test/TDMockApi.js
@@ -109,6 +109,12 @@ TDMockApi.prototype = {
             former_status: "running",
             job_id: "12345"
         });
+
+        this.apiServer.post('/v3/schedule/run/12345/1448928000').reply(200, {
+            jobs: [
+                { job_id: "123456", type: 'hive', scheduled_at: '2015-12-01 00:00:00 UTC' }
+            ]
+        });
     },
 
     start: function() {

--- a/test/td_mock_request_test.js
+++ b/test/td_mock_request_test.js
@@ -104,4 +104,14 @@ describe('TD with mock api', function() {
             });
         });
     });
+
+    describe('#runSchedule', function() {
+        it('should return job record ', function(done) {
+            client.runSchedule('12345', '1448928000', function(err, results) {
+                assert.equal(null, err);
+                assert.equal(1, results.jobs.length);
+                done();
+            });
+        });
+    });
 });


### PR DESCRIPTION
Run-Scheule API use `POST` instead of `GET`.

ref: https://github.com/treasure-data/td-client-ruby/blob/master/lib/td/client/api/schedule.rb#L104