### PR TITLE
Allow user to specify return format of jobResult

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -259,16 +259,26 @@ TDClient.prototype = {
     /**
      *  Returns the result of a specific job.
      *  @param {string} job_id - The job id
+     *  @param {string} format - Format to receive data back in, defaults
+     *                           to tsv
      *  @param {function} callback - Callback function which receives
      *                               error object and results object
      */
-    jobResult: function(job_id, callback) {
-        this._request("/v3/job/result/" + qs.escape(job_id), {
+    jobResult: function(job_id, format, callback) {
+        var opts = {
             method: 'GET',
             qs: { format: 'tsv' }
-        }, callback);
-    },
+        };
 
+        if (typeof format === 'function') {
+            callback = format;
+        }else{
+            opts.qs.format = format;
+        }
+
+        this._request("/v3/job/result/" + qs.escape(job_id), opts, callback);
+    },
+    
     /**
      *  Kill the currently running job
      *  @param {string} job_id - the job id


### PR DESCRIPTION
This PR allows the user to override the default TSV format by specifying which format they would like to receive back from Treasure Data.