### PR TITLE
Change a default protocol to https

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,7 @@ import merge from 'merge';
  *  @param {string} apikey - The API key available from user account.
  *  @param {object} options - Specify the endpoint of TreasureData api.
  *                            options.host = 'api.treasuredata.com'
- *                            options.protocol = 'http'
+ *                            options.protocol = 'https'
  */
 export class TDClient {
 
@@ -37,7 +37,7 @@ export class TDClient {
         this.options = options || {};
         this.options.apikey = apikey;
         this.options.host = this.options.host || 'api.treasuredata.com';
-        this.options.protocol = this.options.protocol || 'http';
+        this.options.protocol = this.options.protocol || 'https';
         this.options.headers = this.options.headers || {};
         this.baseUrl = `${this.options.protocol}://${this.options.host}`;
     }

--- a/test/TDMockApi.js
+++ b/test/TDMockApi.js
@@ -3,7 +3,7 @@ var assert = require('assert');
 
 function TDMockApi(options) {
     this.options = options || {};
-    this.baseUrl = this.options.baseUrl || 'http://mock.api.treasuredata.com';
+    this.baseUrl = this.options.baseUrl || 'https://mock.api.treasuredata.com';
     this.apiServer = nock(this.baseUrl);
 }
 

--- a/test/td_mock_request_test.js
+++ b/test/td_mock_request_test.js
@@ -18,7 +18,7 @@ describe('TD with mock api', function() {
     describe('#getBaseUrl', function() {
         it('should return correct base url', function() {
             var baseUrl = client.baseUrl;
-            assert.equal('http://mock.api.treasuredata.com', baseUrl);
+            assert.equal('https://mock.api.treasuredata.com', baseUrl);
         });
     });
 


### PR DESCRIPTION
Change a default protocol from http to https because TD API will shutdown HTTP access.